### PR TITLE
log pageview on airtable form; turn off analytics debugging

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -1,10 +1,11 @@
 // src/components/button.js
-import { logClick } from "../utils/analytics"
+import { logClick, logPageView } from "../utils/analytics"
+import { CANDIDATE_FORM } from "../utils/constants";
 
 export default function Button({ children, href, style = {} }) {
   return (
     <>
-    <a href={href} style={style} onClick={()=>{logClick()}}>
+    <a href={href} style={style} onClick={()=>{logClick(), logPageView(CANDIDATE_FORM)}}>
         {children}
       </a>
       <style jsx>

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -19,16 +19,17 @@ export const initGA = () => {
     initTracker(LA_GOV_GA_TRACKING_ID, LA_GOV_GA_TRACKER_NAME)
   ]
   ReactGA.initialize(trackers, {
-        debug: true,
+        debug: false,
         alwaysSendToDefaultTracker: false
       });
 }
 
 
-export const logPageView = () => {
-  console.log(`Logging pageview for ${window.location.href}`)
-  ReactGA.set({ page: window.location.href }, [USDR_GA_TRACKER_NAME, LA_GOV_GA_TRACKER_NAME])
-  ReactGA.pageview(window.location.href, [USDR_GA_TRACKER_NAME, LA_GOV_GA_TRACKER_NAME])
+export const logPageView = (page) => {
+  let pageLocation = page || window.location.href
+  console.log(`Logging pageview for ${pageLocation}`)
+  ReactGA.set({ page: pageLocation }, [USDR_GA_TRACKER_NAME, LA_GOV_GA_TRACKER_NAME])
+  ReactGA.pageview(pageLocation, [USDR_GA_TRACKER_NAME, LA_GOV_GA_TRACKER_NAME])
 }
 
 export const logClick = () => {


### PR DESCRIPTION
A round about way to log that someone has looked at the Airtable form in Google Analytics

@pjstein, since Airtable handles fronting the candidate form, is there a way to integrate Google Analytics on their side? In my research, I found a third party app called Zapier that claims to do it, but it doesn't appear free.  